### PR TITLE
Fixed typo in Statistisk Sentralbyrå

### DIFF
--- a/index.html
+++ b/index.html
@@ -285,7 +285,7 @@
 
       <p>NAV, Skatteetaten, NRK, Husbanken, Telenor, Equinor,
       Brønnøysundregistrene, Nasjonalbiblioteket, Statens Vegvesen,
-      Tolldirektoratet, Politiets IKT-Tjenester, Statistisk Sentralbyrå, Statens
+      Tolldirektoratet, Politiets IKT-Tjenester, Statistisk sentralbyrå, Statens
       Lånekasse for Utdanning, Statens Pensjonskasse, Statkraft, Entur, Vy,
       Meteorologisk Institutt, Norsk Institutt for Vannforskning, Universitetets
       Senter for Informasjonsteknologi, Mattilsynet, Difi, Uninett, Oslo


### PR DESCRIPTION
Just a minor change to correct the name of SSB from Statistisk Sentralbyrå to Statistisk sentralbyrå